### PR TITLE
CAW-859: Adding a label to the search block.

### DIFF
--- a/stanford_search_api.module
+++ b/stanford_search_api.module
@@ -61,6 +61,8 @@ function stanford_search_api_search_block_form($form, &$form_state) {
 
   $form['keywords'] = array(
     '#type' => 'textfield',
+    '#title' => t('Search this site'),
+    '#title_display' => 'invisible',
     '#default_value' => isset($_REQUEST['search_api_views_fulltext']) ? check_plain($_REQUEST["search_api_views_fulltext"]) : "",
     '#attributes' => array(
       'placeholder' => t('Search this site...'),


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- AMP is asking us to Provide a valid label for form fields. When on-screen labels are present, they must be explicitly associated with form fields. When on-screen labels are not present, form fields must be given an accessible label.
- We added an invisible label to the keyword field.

# Needed By (Date)
- Soon

# Urgency
- 3/10

# Steps to Test
1. Once on a site, it should add the `<label>` tag above the keyword search filed for the site.
`<label class="element-invisible" for="edit-keywords">Search this site </label>`

# Affected Projects or Products
- Many

# Associated Issues and/or People
- https://stanfordits.atlassian.net/browse/CAW-859

# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)